### PR TITLE
parseCredential() validation parameter

### DIFF
--- a/src/components/Credentials/CredentialInfo.js
+++ b/src/components/Credentials/CredentialInfo.js
@@ -65,13 +65,13 @@ const CredentialInfo = ({ credential, mainClassName = "text-xs sm:text-sm md:tex
 	const [parsedCredential, setParsedCredential] = useState(null);
 
 	useEffect(() => {
-		parseCredential(credential).then((c) => {
+		parseCredential(credential, true).then((c) => {
 			setParsedCredential(c);
 		});
-	}, [credential]);
+	}, []);
 
 	useEffect(() => {
-		parseCredential(credential).then((c) => {
+		parseCredential(credential, true).then((c) => {
 			setParsedCredential(c);
 		});
 	}, [credential]);


### PR DESCRIPTION
added validation param on parseCredential function in order to avoid credential validation everytime it is parsed

TODO

- [x] Select which parseCredential() function call will require validation of the credential