### PR TITLE
Remove URL Cleaning in handleAuthorizationResponse and Perform Cleanup in Credentials Context

### DIFF
--- a/src/components/useCheckURL.ts
+++ b/src/components/useCheckURL.ts
@@ -85,7 +85,7 @@ function useCheckURL(urlToCheck: string): {
 				addLoader();
 				await protocols.openID4VCIClients[credentialIssuerIdentifier].handleAuthorizationResponse(urlToCheck)
 					.then(() => {
-						window.history.replaceState({}, '', `${window.location.pathname}`);
+						// window.history.replaceState({}, '', `${window.location.pathname}`);
 						removeLoader();
 					})
 					.catch(err => {

--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -43,15 +43,10 @@ export const CredentialsProvider = ({ children }) => {
 		isPolling.current = true;
 
 		intervalId.current = setInterval(async () => {
-			const urlParams = new URLSearchParams(window.location.search);
-			if (!urlParams.has('code')) {
-				console.log('Code parameter no longer exists, stopping polling');
-				isPolling.current = false;
-				clearInterval(intervalId.current);
-				return;
-			}
+			console.log('isPolling',isPolling.current);
 
 			if (!isPolling.current) {
+				isPolling.current = false;
 				clearInterval(intervalId.current);
 				return;
 			}
@@ -91,9 +86,11 @@ export const CredentialsProvider = ({ children }) => {
 
 			if (shouldPoll && !newCredentialsFound) {
 				console.log("No new credentials, starting polling");
+				window.history.replaceState({}, '', `${window.location.pathname}`);
 				pollForCredentials();
 			} else if (newCredentialsFound) {
 				console.log("Found new credentials, no need to poll");
+				window.history.replaceState({}, '', `${window.location.pathname}`);
 				updateVcListAndLatestCredentials(vcEntityList);
 			} else {
 				setVcEntityList(vcEntityList);


### PR DESCRIPTION
This PR modifies the `handleAuthorizationResponse` function by removing the URL cleaning logic after a successful authorization response. Instead, the cleanup process is now handled within the `credentialsContext`, ensuring that the new vc handle correct and displaying it correct without reload and with animation.

**Note** this fix feature need to be test with and without notification permission!